### PR TITLE
a fix to a bug in wix ui tpa and stylable mixing

### DIFF
--- a/src/defaultPlugins.ts
+++ b/src/defaultPlugins.ts
@@ -54,6 +54,8 @@ export const defaultPlugins = {
             };
         } else if (tpaParams.fonts[font]) {
             fontValue = tpaParams.fonts[font];
+        } else if (typeof font === 'string' && font.indexOf('font:') === 0) {
+            return font.slice(5, font.length - 1)
         } else {
             return font;
         }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -583,6 +583,28 @@ describe('Index', () => {
         });
     });
 
+    it('should support nested font and fallback', () =>{
+        let css = `.foo { font: "font(string(font:normal normal normal 30px/1.4em raleway;))" }`;
+
+        driver.given.css(css)
+            .given.siteTextPresets({
+            'Body-M': {
+                editorKey: 'font_8',
+                fontFamily: 'raleway',
+                lineHeight: '1.4em',
+                size: '17px',
+                style: 'normal',
+                value: 'font:normal normal normal 17px/1.4em raleway,sans-serif;',
+                weight: 'normal'
+            }
+        });
+        return driver.when.init().then(() => {
+            expect(driver.get.overrideStyleCallArg())
+                .to
+                .equal(`.foo{font: normal normal normal 30px/1.4em raleway;}`);
+        });
+    });
+
     it('should support underline', () => {
         let css = `.foo { font: "font(--fontVar)" }`;
 


### PR DESCRIPTION
there is a bug that only happening in stylable mixin and wix-ui-tpa
for example if you use them with this definition
```  
-st-mixin: TPAText(
    MainTextFont '"fallback(--someVar, font({theme: 'Body-M', size: '16px', lineHeight: '1.33em'}))"'
  );

then the fallback inside is messed up