### PR TITLE
Smart contrast fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ $ npm i -S wix-style-processor
     border-width: "unit(--var-from-settings, px)";                          /* will produce border-width: 42px */
     color: "fallback(color(--var-from-settings), color(color-8))";          /* will return the first none falsy value from left to right */
     width: "calculate(+, 2px, 4%, 3em)";                                    /* will return the native calc function for the given operator and numbers a work around for https://github.com/thysultan/stylis.js/issues/116 */
-    background-color: "smartContrast(color(--base-color), color(--contrast-color))"; /* given a base color and a suggested contrast color, returns the given contrast color if it's A11Y compliant or a lightened/darkened color that will comply */
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "name": "wix-style-processor",
   "description": "An alternative Wix Styles TPA processor",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": {
     "name": "Eran Shabi",
     "email": "erans@wix.com",

--- a/src/defaultPlugins.ts
+++ b/src/defaultPlugins.ts
@@ -114,22 +114,23 @@ export const defaultPlugins = {
             return numbersWithoutTPAParams[0];
         }
     },
-    smartContrast: (baseColor, contrastColorSuggestion) => {
-        const color = new Color(baseColor);
-        let contrastColor = new Color(contrastColorSuggestion);
+    smartBGContrast: (foreground, background) => {
+        const color = new Color(foreground);
+        let contrastColor = new Color(background);
         const baseLuminosity = color.luminosity();
         const originalContrastLuminosity = contrastColor.luminosity();
         const ratio = baseLuminosity / originalContrastLuminosity;
         const direction = ratio < 1 ? 1 : -1;
         let contrast = getNormalizedContrast(color, contrastColor);
+        const luminositySteps = [1, 5, 10, 20, 30, 40, 50, 60];
 
-        while (contrast < 4.5) {
-            contrastColor = contrastColor.lightness(contrastColor.lightness() + direction);
-
-            if (['rgb(255, 255, 255)', 'rgb(0, 0, 0)'].indexOf(contrastColor.rgb().string()) > -1) { // break if white or black
+        // tslint:disable-next-line:prefer-for-of
+        for (let i = 0; i < luminositySteps.length; i++) {
+            if (contrast < 4.5) {
+                contrastColor = contrastColor.lightness(contrastColor.lightness() + (direction * luminositySteps[i]));
+            } else {
                 break;
             }
-
             contrast = getNormalizedContrast(color, contrastColor);
         }
 

--- a/src/defaultPlugins.ts
+++ b/src/defaultPlugins.ts
@@ -114,6 +114,11 @@ export const defaultPlugins = {
             return numbersWithoutTPAParams[0];
         }
     },
+
+    readableFallback: (baseColor: string, suggestedColor: string, fallbackColor: string) => {
+        const contrast = getNormalizedContrast(new Color(baseColor), new Color(suggestedColor));
+        return contrast < 4.5 ? fallbackColor : suggestedColor;
+    },
     smartBGContrast: (foreground, background) => {
         const color = new Color(foreground);
         let contrastColor = new Color(background);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -788,14 +788,22 @@ describe('Index', () => {
         });
     });
 
-    describe('smartContrast css function', () => {
-        const textColor = '#DFF0D8';
-        const lightenedColor = 'rgb(255, 255, 255)';
-        const badBgColor = '#468847';
-        const darkenedColor = 'rgb(60, 116, 61)';
+    describe('smartBGContrast css function', () => {
+        const textColor = 'hsl(196, 57, 39)'; // some kind of blue
+        const goodLightBgColor = new TinyColor(textColor).lighten(60).toHslString(); // 'hsl(196, 57, 99)';
+        const goodDarkBgColor = new TinyColor(textColor).darken(40).toHslString(); // 'hsl(196, 57, 99)';
+        const badLightBgColor = 'hsl(196, 57, 60)'; // brighter than textColor
+        const badDarkBgColor = 'hsl(196, 57, 35)'; // darker than textColor
+        const fallbackForBadLightColor = new TinyColor(badLightBgColor).lighten(40).toRgbString();
+        const fallbackForBadDarkColor = new TinyColor(badDarkBgColor).darken(40).toRgbString();
+
+        // const textColor = '#DFF0D8';
+        // const lightenedColor = 'rgb(255, 255, 255)';
+        // const badBgColor = '#468847';
+        // const darkenedColor = 'rgb(60, 116, 61)';
 
         it('should return darkened color when contrast to low', () => {
-            const css = `.foo {background-color: "smartContrast(${textColor}, ${badBgColor})";}`;
+            const css = `.foo {background-color: "smartBGContrast(${textColor}, ${badDarkBgColor})";}`;
             driver
                 .given.css(css)
                 .given.styleParams({
@@ -807,12 +815,12 @@ describe('Index', () => {
 
             return driver.when.init()
                 .then(() => {
-                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${darkenedColor};}`);
+                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${fallbackForBadDarkColor};}`);
                 });
         });
 
         it('should return lightened color when contrast to low', () => {
-            const css = `.foo {background-color: "smartContrast(${badBgColor}, ${textColor})";}`;
+            const css = `.foo {background-color: "smartBGContrast(${textColor}, ${badLightBgColor})";}`;
             driver
                 .given.css(css)
                 .given.styleParams({
@@ -824,12 +832,12 @@ describe('Index', () => {
 
             return driver.when.init()
                 .then(() => {
-                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${lightenedColor};}`);
+                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${fallbackForBadLightColor};}`);
                 });
         });
 
-        it('should return same color when good contrast', () => {
-            const css = `.foo {background-color: "smartContrast(${textColor}, ${darkenedColor})";}`;
+        it('should return same color when good contrast (dark background)', () => {
+            const css = `.foo {background-color: "smartBGContrast(${textColor}, ${goodDarkBgColor})";}`;
             driver
                 .given.css(css)
                 .given.styleParams({
@@ -841,7 +849,24 @@ describe('Index', () => {
 
             return driver.when.init()
                 .then(() => {
-                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${darkenedColor};}`);
+                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${goodDarkBgColor};}`);
+                });
+        });
+
+        it('should return same color when good contrast (light background)', () => {
+            const css = `.foo {background-color: "smartBGContrast(${textColor}, ${goodLightBgColor})";}`;
+            driver
+                .given.css(css)
+                .given.styleParams({
+                numbers: {},
+                colors: {},
+                fonts: {}
+            })
+                .given.siteTextPresets({});
+
+            return driver.when.init()
+                .then(() => {
+                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${goodLightBgColor};}`);
                 });
         });
     });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,3 +1,4 @@
+import * as Color from 'color';
 import {expect} from 'chai';
 import {IndexDriver} from './index.driver';
 import {hash} from './hash';
@@ -789,13 +790,13 @@ describe('Index', () => {
     });
 
     describe('smartBGContrast css function', () => {
-        const textColor = 'hsl(196, 57, 39)'; // some kind of blue
-        const goodLightBgColor = new TinyColor(textColor).lighten(60).toHslString(); // 'hsl(196, 57, 99)';
-        const goodDarkBgColor = new TinyColor(textColor).darken(40).toHslString(); // 'hsl(196, 57, 99)';
-        const badLightBgColor = 'hsl(196, 57, 60)'; // brighter than textColor
-        const badDarkBgColor = 'hsl(196, 57, 35)'; // darker than textColor
-        const fallbackForBadLightColor = new TinyColor(badLightBgColor).lighten(40).toRgbString();
-        const fallbackForBadDarkColor = new TinyColor(badDarkBgColor).darken(40).toRgbString();
+        const textColor = 'hsl(196, 57%, 39%)'; // some kind of blue
+        const goodLightBgColor = new Color(textColor).lightness(99).rgb().string(); // 'hsl(196, 57, 99)';
+        const goodDarkBgColor = new Color(textColor).lightness(0).rgb().string(); // 'hsl(196, 57, 0)';
+        const badLightBgColor = 'hsl(196, 57%, 60%)'; // brighter than textColor
+        const badDarkBgColor = 'hsl(196, 57%, 35%)'; // darker than textColor
+        const fallbackForBadLightColor = new Color(badLightBgColor).lightness(100).rgb().string();
+        const fallbackForBadDarkColor = new Color(badDarkBgColor).lightness(0).rgb().string();
 
         it('should return darkened color when contrast to low', () => {
             const css = `.foo {background-color: "smartBGContrast(${textColor}, ${badDarkBgColor})";}`;
@@ -862,6 +863,47 @@ describe('Index', () => {
             return driver.when.init()
                 .then(() => {
                     expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{background-color: ${goodLightBgColor};}`);
+                });
+        });
+    });
+
+    describe('readableFallback', () => {
+        const baseColor = 'white';
+        const goodSuggestionColor = '#333333';
+        const fallbackColor = 'black';
+        const badSuggestionColor = 'yellow';
+
+        it('should return suggested color if base and suggestion colors are readable together', () => {
+            const css = `.foo {color: "readableFallback(${baseColor}, ${goodSuggestionColor}, ${fallbackColor})";}`;
+            driver
+                .given.css(css)
+                .given.styleParams({
+                numbers: {},
+                colors: {},
+                fonts: {}
+            })
+                .given.siteTextPresets({});
+
+            return driver.when.init()
+                .then(() => {
+                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{color: ${goodSuggestionColor};}`);
+                });
+        });
+
+        it('should return fallback color if base and suggestion colors are not readable together', () => {
+            const css = `.foo {color: "readableFallback(${baseColor}, ${badSuggestionColor}, ${fallbackColor})";}`;
+            driver
+                .given.css(css)
+                .given.styleParams({
+                numbers: {},
+                colors: {},
+                fonts: {}
+            })
+                .given.siteTextPresets({});
+
+            return driver.when.init()
+                .then(() => {
+                    expect(driver.get.overrideStyleCallArg()).to.equal(`.foo{color: ${fallbackColor};}`);
                 });
         });
     });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -797,11 +797,6 @@ describe('Index', () => {
         const fallbackForBadLightColor = new TinyColor(badLightBgColor).lighten(40).toRgbString();
         const fallbackForBadDarkColor = new TinyColor(badDarkBgColor).darken(40).toRgbString();
 
-        // const textColor = '#DFF0D8';
-        // const lightenedColor = 'rgb(255, 255, 255)';
-        // const badBgColor = '#468847';
-        // const darkenedColor = 'rgb(60, 116, 61)';
-
         it('should return darkened color when contrast to low', () => {
             const css = `.foo {background-color: "smartBGContrast(${textColor}, ${badDarkBgColor})";}`;
             driver

--- a/test/test-setup/style.scss
+++ b/test/test-setup/style.scss
@@ -25,11 +25,11 @@ h1 {
 
 h2[data-hook=bad-contrast-text] {
     color: "color(--textColor)";
-    background-color: "smartContrast(color(--textColor), color(--badBGColor))";
+    background-color: "smartBGContrast(color(--textColor), color(--badBGColor))";
 }
 
 h2[data-hook=good-contrast-text] {
-    background-color: "smartContrast(color(--textColor), color(--goodBGColor))";
+    background-color: "smartBGContrast(color(--textColor), color(--goodBGColor))";
 }
 
 p[data-hook=text] {


### PR DESCRIPTION
changed implementation + added tests.

Also added the `readableFallback` method, which is much simpler.
Given three colors: a base color, a suggestion color, and a fallback color, it checks if the base and suggestion colors are readable.
If they are, the suggestion color is returned, if not, the fallback is returned.

Also removed README documentation.
I think it might be best to leave it undocumented for now, so that we can first try it in wix-ui-tpa for a while.

Related PR: https://github.com/wix-incubator/tpa-style-webpack-plugin/pull/21