### PR TITLE
Nissix plugin scope-packages on wix-style-processor

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ts-node": "^7.0.0",
     "typescript": "3.6.4",
     "velocity": "^0.7.2",
-    "yoshi": "^3.0.0",
+    "@wix/yoshi": "^3.0.0",
     "yoshi-style-dependencies": "^3.0.0"
   },
   "yoshi": {

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha-ts.ts');
+module.exports = require('@wix/yoshi/config/wallaby-mocha-ts.ts');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.13s



Output Log:
Migrating package "wix-style-processor" in .


## Migration from non scope to @wix/scoped packages
> /tmp/2000685d06b61ce6fa0f47007ccdb58b

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
```

